### PR TITLE
Feature/modeswitch  modes without uac

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tobit-chayns_components",
-  "version": "1.0.39",
+  "version": "1.0.40",
   "description": "some standalone react components",
   "main": "index.js",
   "scripts": {

--- a/react-chayns-animations/README.md
+++ b/react-chayns-animations/README.md
@@ -49,4 +49,5 @@ Both ways of initialization allow the following settings (No checking in the Jav
 | Property   | Description                                                                                        | Type    | Default Value |
 |------------|-----------------------------------------------------------------------------------------------------|--------|--------------|
 | componenent | The component that should get animated                                                 | React.Component| --required--             |
+| expandedWidth | The width the modal-box/overlay should have                                                 | string, number | same width as the normal element |
 | * | Props that should be set to your own component (includes children)                                                | any |            |

--- a/react-chayns-modeswitch/examples/Example.jsx
+++ b/react-chayns-modeswitch/examples/Example.jsx
@@ -14,6 +14,9 @@ export default class Example extends React.Component {
                     id: 1,
                     uacIds: [1, 34542],
                     name: 'Chayns Manager'
+                },{
+                    id: 2,
+                    name: 'Employee'
                 }],
                 save: true,
                 onChange: (data) => {
@@ -49,6 +52,12 @@ export default class Example extends React.Component {
                 <Mode modes={[0,1]}>
                     <div>
                         <button onClick={this.getModeSwitchStatus}>ModeSwitch Status</button>
+                    </div>
+                </Mode>
+
+                <Mode modes={[2]}>
+                    <div>
+                        Mitarbeiter
                     </div>
                 </Mode>
 

--- a/react-chayns-modeswitch/src/component/ModeSwitchHelper.js
+++ b/react-chayns-modeswitch/src/component/ModeSwitchHelper.js
@@ -53,17 +53,21 @@ export default class ModeSwitchHelper {
                     if (!groups[i].uacId && !groups[i].uacIds) {
                         let groupObject = getGroupObject(groups[i].id, groups[i].name, [0]);
                         allowedGroups.push(groupObject);
+
+                        if (groupObject.id === savedModeId) {
+                            changeGroup = true;
+                            changeGroupIndex = allowedGroups.length - 1;
+                            changeGroupValue = groupObject;
+                        }
                     } else {
                         let uacIds = getUacIds(groups[i]);
                         let allowedUacs = getAllowedUacIdsFromArray(uacIds);
 
                         if (allowedUacs.length > 0) {
-
                             let groupObject = getGroupObject(groups[i].id, groups[i].name, allowedUacs);
                             allowedGroups.push(groupObject);
 
-
-                            if (groupObject.id == savedModeId) {
+                            if (groupObject.id === savedModeId) {
                                 changeGroup = true;
                                 changeGroupIndex = allowedGroups.length - 1;
                                 changeGroupValue = groupObject;
@@ -81,7 +85,6 @@ export default class ModeSwitchHelper {
 
 
                     initialized = true;
-
 
                     if (changeGroup) {
                         getChangeListener()(changeGroupValue);


### PR DESCRIPTION
Fixed the error that the saved mode is not loaded correctly, when it has no uacIds specified.
Should solve _Issue #8_.

Updated version to **1.0.40**.