### PR TITLE
Add max-height to calendar__months

### DIFF
--- a/src/react-chayns-calendar/style.scss
+++ b/src/react-chayns-calendar/style.scss
@@ -27,6 +27,7 @@
   left: -50%;
   width: 200%;
   height: 100%;
+  max-height: 180px;
 }
 
 .month{


### PR DESCRIPTION
Set max-height to 180px to avoid the expandation of the tapps hight to the maximum