### PR TITLE
Fix word breaking in EmojiInput component

### DIFF
--- a/src/react-chayns-emoji_input/index.scss
+++ b/src/react-chayns-emoji_input/index.scss
@@ -25,6 +25,7 @@
 
   .message--input {
     font-weight: 400 !important;
+    word-break: break-word;
     max-height: 100px;
     min-height: 33px;
     overflow-y: auto;


### PR DESCRIPTION
There is only one CSS style missing in stylesheet of EmojiInput component to fix word break for long words in input field.