### PR TITLE
Remove unnecessary buttons in dialog of SelectButton

### DIFF
--- a/src/react-chayns-selectbutton/component/SelectButton.jsx
+++ b/src/react-chayns-selectbutton/component/SelectButton.jsx
@@ -83,6 +83,7 @@ export default class SelectButton extends Component {
             quickfind: quickFind,
             multiselect: multiSelect,
             list: _list,
+            buttons: multiSelect || [],
         }).then((result) => {
             if (onSelect && result.buttonType > 0) {
                 onSelect(this.getReturnList(result));


### PR DESCRIPTION
In single select mode (multiSelect = false), clicking on an item already confirms the selection, making the buttons unnecessary