### PR TITLE
Fix end of month is start of day

### DIFF
--- a/src/react-chayns-calendar/component/Calendar.jsx
+++ b/src/react-chayns-calendar/component/Calendar.jsx
@@ -102,25 +102,25 @@ export default class Calendar extends Component {
                 title: monthNames[_leftHidden.getMonth()],
                 className: 'month',
                 startDate: _leftHidden,
-                endDate: new Date(_leftHidden.getFullYear(), _leftHidden.getMonth() + 1, 0),
+                endDate: new Date(_leftHidden.getFullYear(), _leftHidden.getMonth() + 1, _leftHidden.getDate(), 23, 59, 59, 999),
             },
             {
                 title: monthNames[_rightShown.getMonth()],
                 className: 'month',
                 startDate: _rightShown,
-                endDate: new Date(_rightShown.getFullYear(), _rightShown.getMonth() + 1, 0),
+                endDate: new Date(_rightShown.getFullYear(), _rightShown.getMonth() + 1, _rightShown.getDate(), 23, 59, 59, 999),
             },
             {
                 title: monthNames[_focus.getMonth()],
                 className: 'month',
                 startDate: new Date(_focus.getFullYear(), _focus.getMonth(), 1),
-                endDate: new Date(_focus.getFullYear(), _focus.getMonth() + 1, 0),
+                endDate: new Date(_focus.getFullYear(), _focus.getMonth() + 1, _focus.getDate(), 23, 59, 59, 999),
             },
             {
                 title: monthNames[_rightHidden.getMonth()],
                 className: 'month',
                 startDate: _rightHidden,
-                endDate: new Date(_rightHidden.getFullYear(), _rightHidden.getMonth() + 1, 0),
+                endDate: new Date(_rightHidden.getFullYear(), _rightHidden.getMonth() + 1, _rightHidden.getDate(), 23, 59, 59, 999),
             }];
 
         this.newMonths = months;


### PR DESCRIPTION
Currently the endDate of each month is the **start** of the last day. This can lead to unexpected behavior where the last day won't be highlighted because the given date has either hours/minutes/seconds > 0.

This PR sets the endDate to the **end** of the last day.