### PR TITLE
Fix missing days from last months

### DIFF
--- a/src/react-chayns-calendar/component/MonthTable.jsx
+++ b/src/react-chayns-calendar/component/MonthTable.jsx
@@ -96,7 +96,7 @@ export default class MonthTable extends PureComponent {
                 } else {
                     for (let j = 6; j > 0; j -= 1) {
                         _row.push({
-                            date: new DateStorage.From(startDate.getFullYear(), startDate.getMonth(), startDate.getDay() - j),
+                            date: new DateStorage.From(startDate.getFullYear(), startDate.getMonth(), startDate.getDate() - j),
                             inMonth: false,
                         });
                     }


### PR DESCRIPTION
This PR fixes an issue where days from the last month were missing.

Example:
August has 31 days. In September the last grayed out day is the 30th directly followed by the 1st.

The use of getDay() instead of getDate() was likely a typo since getDate() is normally used.
