### PR TITLE
Fix es lint error in DateInfo component/Update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chayns-components",
-  "version": "4.12.10",
+  "version": "4.12.11",
   "description": "Some react components for chayns®",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/react-chayns-dateinfo/component/DateInfo.jsx
+++ b/src/react-chayns-dateinfo/component/DateInfo.jsx
@@ -18,7 +18,7 @@ export default class DateInfo extends PureComponent {
     };
 
     static defaultProps = {
-        children: <div/>,
+        children: <div />,
         language: (chayns.env.language || navigator.language || 'de').substring(0, 2).toLowerCase(),
         date2: null,
         showTime: null,


### PR DESCRIPTION
Fixed a es lint error which let the build crash. The webstorm auto formatter removed a space in an empty Tag, which was required for es lint.

Updated Version in package.json to 4.12.11