### PR TITLE
Add linkText property to sharingBar

### DIFF
--- a/src/react-chayns-sharingbar/README.md
+++ b/src/react-chayns-sharingbar/README.md
@@ -7,13 +7,13 @@ The SharingBar is part of the *chayns-components* package. It can be installed v
 
 ## Usage of the SharingBar ##
 
-At least one of the components has to be imported:
+Import the component:
 
 ```jsx harmony
 import { SharingBar } from 'chayns-components';
 ```
 
-You can use the SharingBar like this:
+You can then use the SharingBar like this:
 
 ```jsx harmony
 <SharingBar/>
@@ -23,11 +23,12 @@ You can use the SharingBar like this:
 
 The following properties can be set on the SharingBar-Component
 
-| Property   | Description                                                                                        | Type    | Default Value |
-|------------|-----------------------------------------------------------------------------------------------------|--------|--------------|
-| link | The link shared by the SharingBar                                                           | String | Link to the current Tapp |
-| className | Additional CSS-Classes that should be set to the button                                                        | String |
-| stopPropagation     | Stops the click propagation to parent elements                                                      | bool          | false         |
+| Property          | Description                                                | Type   | Default Value            |
+|-------------------|------------------------------------------------------------|--------|--------------------------|
+| link              | The link shared by the SharingBar                          | String | Link to the current Tapp |
+| linkText          | A message added in front of the shared link                | String |                          |
+| className         | Additional CSS-Classes that should be set to the button    | String |                          |
+| stopPropagation   | Stops the click propagation to parent elements             | bool   | false                    |
 
 
 ## Examples ##

--- a/src/react-chayns-sharingbar/component/SharingBar.jsx
+++ b/src/react-chayns-sharingbar/component/SharingBar.jsx
@@ -7,6 +7,7 @@ import { getAvailableShareProviders, getDefaultShareLink } from './sharingHelper
 export default class SharingBar extends Component {
     static propTypes = {
         link: PropTypes.string,
+        linkText: PropTypes.string,
         className: PropTypes.string,
         stopPropagation: PropTypes.bool,
         style: PropTypes.string,
@@ -14,6 +15,7 @@ export default class SharingBar extends Component {
 
     static defaultProps = {
         link: null,
+        linkText: '',
         className: null,
         stopPropagation: false,
         style: null,
@@ -29,7 +31,7 @@ export default class SharingBar extends Component {
 
     componentDidMount() {
         getAvailableShareProviders().then((provider) => {
-            const { link, stopPropagation } = this.props;
+            const { link, linkText, stopPropagation } = this.props;
 
             const sharingItems = [];
 
@@ -42,6 +44,7 @@ export default class SharingBar extends Component {
                             provider={item}
                             key={item.id}
                             link={link || getDefaultShareLink()}
+                            linkText={linkText}
                             stopPropagation={stopPropagation}
                         />
                     ));

--- a/src/react-chayns-sharingbar/component/SharingBarItem.jsx
+++ b/src/react-chayns-sharingbar/component/SharingBarItem.jsx
@@ -5,6 +5,7 @@ import share from './sharingActions';
 import Icon from '../../react-chayns-icon/component/Icon';
 import Button from '../../react-chayns-button/component/Button';
 import Tooltip from '../../react-chayns-tooltip/component/Tooltip';
+import { shareOptions } from './sharingProvider';
 
 export default class SharingBarItem extends Component {
     static propTypes = {
@@ -13,17 +14,22 @@ export default class SharingBarItem extends Component {
         provider: PropTypes.object.isRequired,
         link: PropTypes.string.isRequired,
         stopPropagation: PropTypes.bool.isRequired,
+        linkText: PropTypes.string,
+    };
+
+    static defaultProps = {
+        linkText: '',
     };
 
     onClick = (e) => {
-        const { provider, link, stopPropagation } = this.props;
+        const {
+            link,
+            linkText,
+            provider,
+            stopPropagation,
+        } = this.props;
 
-        if (provider.id === 2 && provider.action === 1) {
-            const linkToShare = link ? link.replace('=', '%3D') : '';
-            share(provider, linkToShare);
-        } else {
-            share(provider, link);
-        }
+        share(provider, link, linkText);
 
         if (stopPropagation) e.stopPropagation();
     };
@@ -35,7 +41,7 @@ export default class SharingBarItem extends Component {
             provider,
         } = this.props;
 
-        if (provider.action === 0) {
+        if (provider.id === shareOptions.COPY) {
             return (
                 <Tooltip content={{ text: 'Kopiert.' }} ref={ref => this.tooltip = ref} removeIcon>
                     <Button

--- a/src/react-chayns-sharingbar/component/sharingHelper.js
+++ b/src/react-chayns-sharingbar/component/sharingHelper.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-param-reassign,no-else-return */
-import { shareProvider, shareActions } from './sharingProvider';
+import { shareProvider } from './sharingProvider';
 
 export function getAvailableShareProviders() {
     if (chayns.env.isApp || chayns.env.isMyChaynsApp) {
@@ -14,7 +14,7 @@ export function getAvailableShareProviders() {
 
                 if (shareApp !== undefined) {
                     curProvider.available = true;
-                    curProvider.action = shareActions.shareWithApp;
+                    curProvider.useApp = true;
                 }
             });
 
@@ -32,7 +32,7 @@ export function getAvailableShareProviders() {
 
                     if (shareApp) {
                         curProvider.available = true;
-                        curProvider.action = shareActions.shareWithApp;
+                        curProvider.useApp = true;
                     }
                 });
             }

--- a/src/react-chayns-sharingbar/component/sharingProvider.js
+++ b/src/react-chayns-sharingbar/component/sharingProvider.js
@@ -5,83 +5,78 @@ import { faEnvelope } from '@fortawesome/free-regular-svg-icons/faEnvelope';
 import { faCopy } from '@fortawesome/free-regular-svg-icons/faCopy';
 import { faShareAlt } from '@fortawesome/free-solid-svg-icons/faShareAlt';
 
+export const shareOptions = {
+    COPY: 0,
+    MAIL: 1,
+    WHATSAPP: 2,
+    FACEBOOK: 3,
+    TWITTER: 5,
+    CUSTOM_CHAYNS: 10,
+    CUSTOM_ALL: 11,
+};
+
 export const shareProvider = [
     {
-        id: 2,
+        id: shareOptions.WHATSAPP,
         providerId: 1,
         name: 'WhatsApp',
         androidIdentifier: 'com.whatsapp',
         icon: faWhatsapp,
-        action: 1,
         url: 'https://api.whatsapp.com/send?text={url}',
         available: true,
     },
     {
-        id: 0,
+        id: shareOptions.COPY,
         providerId: -1,
         name: 'Zwischenablage',
         androidIdentifier: null,
         icon: faCopy,
-        action: 0,
         url: null,
         available: true,
     },
     {
-        id: 1,
+        id: shareOptions.MAIL,
         providerId: 0,
         name: 'Mail',
         androidIdentifier: null,
         icon: faEnvelope,
-        action: 1,
         url: 'mailto:?body={url}',
         available: true,
     },
     {
-        id: 3,
+        id: shareOptions.FACEBOOK,
         providerId: 2,
         name: 'Facebook',
         androidIdentifier: 'com.facebook.katana',
         icon: faFacebookF,
-        action: 1,
         url: 'http://www.facebook.com/dialog/share?app_id=472449496108149&display=page&href={url}&redirect_uri=http://facebook.com',
         available: true,
     },
     {
-        id: 5,
+        id: shareOptions.TWITTER,
         providerId: 5,
         name: 'Twitter',
         androidIdentifier: null,
         icon: faTwitter,
-        action: 1,
-        url: 'http://twitter.com/intent/tweet?text=&url={url}&hashtags=chayns',
+        url: 'http://twitter.com/intent/tweet?text={linkText}&url={url}&hashtags=chayns',
         available: true,
     },
     {
-        id: 10,
+        id: shareOptions.CUSTOM_CHAYNS,
         providerId: -1,
         name: 'Share',
         androidIdentifier: null,
         icon: faShareAlt,
-        action: 2,
         url: null,
         available: false,
     },
     {
-        id: 11,
+        id: shareOptions.CUSTOM_ALL,
         providerId: -1,
         name: 'Share',
         androidIdentifier: null,
         icon: faShareAlt,
-        action: 3,
         url: null,
         available: false,
     },
-
 ];
-
-export const shareActions = {
-    copyToClipboard: 0,
-    shareWithUrl: 1,
-    shareWithApp: 2,
-    webShareApi: 3,
-};


### PR DESCRIPTION
This pull request adds a _linkText_ property to the sharingBar.
The _linkText_ will be added in front of the shared link.

To prevent action conflicts (e.g. Facebook does not allow the href property to contain any text besides an url) the share method was restructured using the newly introduced sharingOptions constant.

For further information about how each action handles the text take a look at the 'share()' function.
