### PR TITLE
:bug: Fix bug with PersonFinder not calling onChange after being cleared

### DIFF
--- a/src/react-chayns-personfinder/component/SimplePersonFinder.jsx
+++ b/src/react-chayns-personfinder/component/SimplePersonFinder.jsx
@@ -66,7 +66,13 @@ export default class SimplePersonFinder extends Component {
     }
 
     handleOnChange(inputValue) {
-        const { onInput } = this.props;
+        const { onInput, onChange } = this.props;
+        const { selectedValue } = this.state;
+
+        if (selectedValue) {
+            onChange(null);
+        }
+
         this.setState({
             inputValue,
             selectedValue: false,


### PR DESCRIPTION
With this change, the PersonFinder will call onChange with the value of null, if a value was selected before but now is cleared or a character of the values name is deleted