### PR TITLE
Fix unable to add classNames to textarea

### DIFF
--- a/src/react-chayns-textarea/component/TextArea.jsx
+++ b/src/react-chayns-textarea/component/TextArea.jsx
@@ -98,8 +98,7 @@ const TextArea = ({
 
     const classNames = classnames('input', {
         'input--disabled': disabled,
-        className,
-    });
+    }, className);
 
     return (
         <textarea


### PR DESCRIPTION
This PR fixes the TextArea's _className_ prop.

_className_ wasn't forwarded to classnames() as a third parameter but as an additional parameter of the conditional style object. This resulted in the TextArea always receiving the class "className" instead of the actual class.

