### PR TITLE
Fix sharing bar cursor

### DIFF
--- a/src/react-chayns-sharingbar/component/SharingBar.jsx
+++ b/src/react-chayns-sharingbar/component/SharingBar.jsx
@@ -62,7 +62,7 @@ function SharingBar({
                 childrenStyle={{ display: 'inline' }}
             >
                 <Icon icon={faShareAlt} className="sharing-bar__icon"/>
-                <span className="sharing-bar_text">Teilen</span>
+                <span className="sharing-bar__text">Teilen</span>
             </ContextMenu>
         </div>
     );

--- a/src/react-chayns-sharingbar/component/sharingBar.scss
+++ b/src/react-chayns-sharingbar/component/sharingBar.scss
@@ -1,5 +1,8 @@
 .sharing-bar {
-  cursor: pointer;
+  > div {
+    cursor: pointer;
+  }
+
   &__icon {
     margin-right: 5px;
   }


### PR DESCRIPTION
'cursor: pointer;' is applied to the full size wrapper instead of the actual sharing element.

Adds an additional underscore to 'sharing-bar_text' to match BEM structure.