### PR TITLE
Badge Component: Replace badgeRef with ref

### DIFF
--- a/src/react-chayns-badge/README.md
+++ b/src/react-chayns-badge/README.md
@@ -1,10 +1,10 @@
-# Badge #
+# Badge
 
-The Badge is part of the *chayns-components* package. It can be installed via npm:
+The Badge is part of the _chayns-components_ package. It can be installed via npm:
 
     npm install -S chayns-components@latest
 
-## Usage ##
+## Usage
 
 The component has to be imported:
 
@@ -18,19 +18,18 @@ You can use the badge like this:
 <Badge>1</Badge>
 ```
 
-
-## Props ##
+## Props
 
 The following properties can be set on the Badge:
 
-| Property   | Description                                                                                         | Type   | Default Value |
-|------------|-----------------------------------------------------------------------------------------------------|--------|---------------|
-| children   | Value of the badge                                                                                  | node   | *required*    |
-| className  | ClassName added to the badge                                                                        | string |               |
-| badgeRef   | Reference to the badge div                                                                          | func   |               |
-| style      | Extra styles for badge element                                                                      | object |               |
+| Property  | Description                  | Type   | Default Value |
+| --------- | ---------------------------- | ------ | ------------- |
+| children  | Value of the badge           | node   | _required_    |
+| className | ClassName added to the badge | string |               |
+| ref       | Reference to the badge div   | func   |               |
 
+Additional props will be passed on to the badge div.
 
-## Example ##
+## Example
 
 You can take a look at the **examples** folder in the **react-chayns-badge** repository. There you can find an appropriate way of implementing the **Badge** to your chayns-Tapp.

--- a/src/react-chayns-badge/component/Badge.jsx
+++ b/src/react-chayns-badge/component/Badge.jsx
@@ -1,33 +1,34 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { forwardRef, useCallback, useState } from 'react';
 
-export default class Badge extends PureComponent {
-    componentDidMount() {
-        this.ref.style['min-width'] = `${this.ref.getBoundingClientRect().height}px`;
-    }
+const Badge = forwardRef(({ children, className, ...other }, ref) => {
+    const [minWidth, setMinWidth] = useState();
 
-    render() {
-        const {
-            children, className, badgeRef, ...other
-        } = this.props;
+    const measureRef = useCallback((node) => {
+        if (node) {
+            setMinWidth(node.getBoundingClientRect().height);
+        }
+    }, []);
 
-        return (
-            <div
-                className={classNames(className, 'badge')}
-                ref={(ref) => {
-                    this.ref = ref;
-                    if (badgeRef) {
-                        badgeRef(ref);
-                    }
-                }}
-                {...other}
-            >
-                {children}
-            </div>
-        );
-    }
-}
+    return (
+        <div
+            className={classNames(className, 'badge')}
+            ref={(node) => {
+                measureRef(node);
+                if (ref) {
+                    ref(node);
+                }
+            }}
+            style={{ minWidth }}
+            {...other}
+        >
+            {children}
+        </div>
+    );
+});
+
+export default Badge;
 
 Badge.propTypes = {
     children: PropTypes.node.isRequired,

--- a/src/react-chayns-badge/component/Badge.jsx
+++ b/src/react-chayns-badge/component/Badge.jsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { forwardRef, useCallback, useState } from 'react';
 
-const Badge = forwardRef(({ children, className, ...other }, ref) => {
+const Badge = forwardRef(({ children, className, style, ...other }, ref) => {
     const [minWidth, setMinWidth] = useState();
 
     const measureRef = useCallback((node) => {
@@ -20,7 +20,7 @@ const Badge = forwardRef(({ children, className, ...other }, ref) => {
                     ref(node);
                 }
             }}
-            style={{ minWidth }}
+            style={{ minWidth, ...style }}
             {...other}
         >
             {children}
@@ -33,10 +33,13 @@ export default Badge;
 Badge.propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
+    // eslint-disable-next-line react/forbid-prop-types
+    style: PropTypes.object,
 };
 
 Badge.defaultProps = {
     className: '',
+    style: undefined,
 };
 
 Badge.displayName = 'Badge';

--- a/src/react-chayns-badge/component/Badge.jsx
+++ b/src/react-chayns-badge/component/Badge.jsx
@@ -33,12 +33,10 @@ export default Badge;
 Badge.propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
-    badgeRef: PropTypes.func,
 };
 
 Badge.defaultProps = {
     className: '',
-    badgeRef: null,
 };
 
 Badge.displayName = 'Badge';

--- a/src/react-chayns-badge/component/Badge.jsx
+++ b/src/react-chayns-badge/component/Badge.jsx
@@ -2,31 +2,36 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { forwardRef, useCallback, useState } from 'react';
 
-const Badge = forwardRef(({ children, className, style, ...other }, ref) => {
-    const [minWidth, setMinWidth] = useState();
+const Badge = forwardRef(
+    ({ children, className, style, badgeRef, ...other }, ref) => {
+        const [minWidth, setMinWidth] = useState();
 
-    const measureRef = useCallback((node) => {
-        if (node) {
-            setMinWidth(node.getBoundingClientRect().height);
-        }
-    }, []);
+        const measureRef = useCallback((node) => {
+            if (node) {
+                setMinWidth(node.getBoundingClientRect().height);
+            }
+        }, []);
 
-    return (
-        <div
-            className={classNames(className, 'badge')}
-            ref={(node) => {
-                measureRef(node);
-                if (ref) {
-                    ref(node);
-                }
-            }}
-            style={{ minWidth, ...style }}
-            {...other}
-        >
-            {children}
-        </div>
-    );
-});
+        return (
+            <div
+                className={classNames(className, 'badge')}
+                ref={(node) => {
+                    measureRef(node);
+                    if (ref) {
+                        ref(node);
+                    }
+                    if (badgeRef) {
+                        badgeRef(node);
+                    }
+                }}
+                style={{ minWidth, ...style }}
+                {...other}
+            >
+                {children}
+            </div>
+        );
+    }
+);
 
 export default Badge;
 
@@ -35,11 +40,13 @@ Badge.propTypes = {
     className: PropTypes.string,
     // eslint-disable-next-line react/forbid-prop-types
     style: PropTypes.object,
+    badgeRef: PropTypes.func,
 };
 
 Badge.defaultProps = {
     className: '',
     style: undefined,
+    badgeRef: undefined,
 };
 
 Badge.displayName = 'Badge';


### PR DESCRIPTION
Use Reacts forwardRef function along with a function components to get rid of custom prop `badgeRef` in favor of Reacts standard `ref` prop.