### PR TITLE
Button Component: Change buttonRef to ref and add type prop

### DIFF
--- a/src/react-chayns-button/README.md
+++ b/src/react-chayns-button/README.md
@@ -1,11 +1,10 @@
-# Button / ChooseButton #
+# Button / ChooseButton
 
-The Button/ChooseButton is part of the *chayns-components* package. It can be installed via npm:
+The Button/ChooseButton is part of the _chayns-components_ package. It can be installed via npm:
 
     npm install -S chayns-components@latest
 
-
-## Usage ##
+## Usage
 
 At least one of the components has to be imported:
 
@@ -19,25 +18,25 @@ You can use the button like this:
 <Button>Test</Button>
 ```
 
-
-## Props ##
+## Props
 
 The following properties can be set on the Button and the ChooseButton-Component
 
-| Property     | Description                                                                          | Type          | Default Value                        |
-|--------------|--------------------------------------------------------------------------------------|---------------|--------------------------------------|
-| children     | Value of the button                                                                  | string        | *required*                           |
-| chooseButton | Render Button as ChooseButton (not necessary when using the ChooseButton-component)  | bool          | false (Button) / true (ChooseButton) |
-| disabled     | Disabled the button and set the correct style                                        | bool          | false                                |
-| secondary    | Renders Button as a secondary button                                                 | bool          | false                                |
-| onClick      | onClick-event                                                                        | function      |                                      |
-| className    | Additional CSS-Classes that should be set to the button                              | string        |                                      |
-| style        | Additional styles that should be set to the button                                   | Object        |                                      |
-| buttonRef    | Exposes the button DOM Ref to the parent component                                   | func          |                                      |
-| icon         | Renders Button as IconButton (fa- or ts-icon)                                        | string/object |                                      |
-| stopPropagation | Stops the click propagation to parent elements                                    | bool          | false                                |
+| Property        | Description                                                                           | Type          | Default Value                        |
+| --------------- | ------------------------------------------------------------------------------------- | ------------- | ------------------------------------ |
+| children        | Value of the button                                                                   | string        | _required_                           |
+| chooseButton    | Render Button as ChooseButton (not necessary when using the ChooseButton-component)   | bool          | false (Button) / true (ChooseButton) |
+| disabled        | Disabled the button and set the correct style                                         | bool          | false                                |
+| secondary       | Renders Button as a secondary button                                                  | bool          | false                                |
+| onClick         | onClick-event                                                                         | function      |                                      |
+| className       | Additional CSS-Classes that should be set to the button                               | string        |                                      |
+| ref             | Ref that will be passed on to the button-element                                      | func          |                                      |
+| icon            | Renders Button as IconButton (fa- or ts-icon)                                         | string/object |                                      |
+| stopPropagation | Stops the click propagation to parent elements                                        | bool          | false                                |
+| type            | The type-attribute applied to the button-element. (`'button'`\|`'submit'`\|`'reset'`) | string        | 'button'                             |
 
+Additional props will be passed on to the underlying `button`-element.
 
-## Example ##
+## Example
 
 You can take a look at the **examples** folder in the **react-chayns-button** repository. There you can find an appropriate way of implementing the **Button** to your chayns-Tapp.

--- a/src/react-chayns-button/component/Button.jsx
+++ b/src/react-chayns-button/component/Button.jsx
@@ -1,69 +1,59 @@
 /* eslint-disable react/forbid-prop-types */
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React, { forwardRef } from 'react';
 import Icon from '../../react-chayns-icon/component/Icon';
 
-export default class Button extends PureComponent {
-    constructor(props) {
-        super(props);
-        this.handleClick = this.handleClick.bind(this);
-    }
+const Button = forwardRef((props, ref) => {
+    const {
+        chooseButton,
+        disabled,
+        children,
+        className,
+        icon,
+        secondary,
+        stopPropagation,
+        onClick,
+        type,
+        ...other
+    } = props;
 
-    handleClick(event) {
-        const { onClick, disabled, stopPropagation } = this.props;
-
+    const handleClick = (event) => {
         if (onClick && !disabled) onClick(event);
         if (stopPropagation) event.stopPropagation();
-    }
+    };
 
-    render() {
-        const {
-            chooseButton,
-            disabled,
-            children,
-            className,
-            style,
-            buttonRef,
-            icon,
-            secondary,
-            stopPropagation, // exclude this prop from ...other
-            ...other
-        } = this.props;
-
-        return (
-            <button
-                type="button"
-                className={classNames({
-                    button: !chooseButton,
-                    choosebutton: chooseButton,
-                    'button--disabled': disabled,
-                    'button--secondary': secondary,
-                    'button--icon': icon && !chooseButton,
-                    'choosebutton--icon': icon && chooseButton,
-                    [className]: className,
-                })}
-                onClick={this.handleClick}
-                style={style}
-                disabled={disabled}
-                ref={buttonRef}
-                {...other}
-            >
-                {icon ? (
-                    <span
-                        className={classNames({
-                            button__icon: !chooseButton,
-                            choosebutton__icon: chooseButton,
-                        })}
-                    >
-                        <Icon icon={icon}/>
-                    </span>
-                ) : null}
-                {children}
-            </button>
-        );
-    }
-}
+    return (
+        // eslint-disable-next-line react/button-has-type
+        <button
+            type={type}
+            className={classNames(className, {
+                button: !chooseButton,
+                choosebutton: chooseButton,
+                'button--disabled': disabled,
+                'button--secondary': secondary,
+                'button--icon': icon && !chooseButton,
+                'choosebutton--icon': icon && chooseButton,
+            })}
+            onClick={handleClick}
+            disabled={disabled}
+            ref={ref}
+            {...other}
+        >
+            {icon && (
+                <span
+                    className={classNames({
+                        button__icon: !chooseButton,
+                        choosebutton__icon: chooseButton,
+                    })}
+                >
+                    <Icon icon={icon}/>
+                </span>
+            )}
+            {children}
+        </button>
+    );
+});
 
 Button.propTypes = {
     children: PropTypes.node.isRequired,
@@ -71,16 +61,15 @@ Button.propTypes = {
     disabled: PropTypes.bool,
     onClick: PropTypes.func,
     className: PropTypes.string,
-    style: PropTypes.object,
     buttonRef: PropTypes.func,
     icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     secondary: PropTypes.bool,
     stopPropagation: PropTypes.bool,
+    type: PropTypes.oneOf(['button', 'submit', 'reset']),
 };
 
 Button.defaultProps = {
     buttonRef: null,
-    style: null,
     className: null,
     onClick: null,
     disabled: false,
@@ -88,6 +77,7 @@ Button.defaultProps = {
     icon: null,
     secondary: false,
     stopPropagation: false,
+    type: 'button',
 };
 
 Button.displayName = 'Button';


### PR DESCRIPTION
The type-prop can be useful when used in combination with HTML-forms, which was not possible before.

The buttonRef was changed to Reacts regular ref prop to standardize the components.