### PR TITLE
Forward preventParams to image

### DIFF
--- a/src/react-chayns-gallery/README.md
+++ b/src/react-chayns-gallery/README.md
@@ -42,6 +42,7 @@ The following properties can be set on the Gallery-Component
 | height       | Height of the gallery in px, not used in deleteMode  | number   | width of the gallery |           |
 | width        | Width of the gallery in px                           | number   | 100%              |              |
 | stopPropagation | Stops the click propagation to parent elements    | bool     | false             |              |
+| preventParams | Forwarded to the Image component. See details below.  | object/bool|        |              | 
 
 ### Image Props ###
 

--- a/src/react-chayns-gallery/component/Gallery.jsx
+++ b/src/react-chayns-gallery/component/Gallery.jsx
@@ -147,6 +147,7 @@ export default class Gallery extends Component {
             deleteMode,
             dragMode,
             className,
+            preventParams,
             stopPropagation,
             onClick,
         } = this.props;
@@ -234,6 +235,7 @@ export default class Gallery extends Component {
                                     >
                                         <Image
                                             key={`image${index}`}
+                                            preventParams={preventParams}
                                             image={image.url || image.file || image}
                                             moreImages={(index === 3 && defaultMode) ? numberOfImages - 1 - index : 0}
                                             onClick={


### PR DESCRIPTION
Forward the _preventParams_ prop provided to the Gallery to the Image component for better control over how the image is displayed.