### PR TITLE
Feature/v5 drafts/modular list item

### DIFF
--- a/packages/core/src/components/list/list-item/ListItem.tsx
+++ b/packages/core/src/components/list/list-item/ListItem.tsx
@@ -51,6 +51,11 @@ type ListItemProps = {
      */
     onLongPress?: TouchEventHandler<HTMLDivElement>;
     /**
+     * Elements that are displayed on the left side of the header. If multiple
+     * elements are specified, they are displayed one aside the other.
+     */
+    leftElements?: [ReactNode, ...ReactNode[]];
+    /**
      * Elements that are displayed on the right side of the header. If multiple
      * elements are specified, they are displayed one below the other.
      */
@@ -78,6 +83,7 @@ const ListItem: FC<ListItemProps> = ({
     isDefaultOpen,
     onClick,
     onLongPress,
+    leftElements,
     rightElements,
     subtitle,
     shouldShowRoundImage,
@@ -135,6 +141,7 @@ const ListItem: FC<ListItemProps> = ({
                 isOpen={isOpen}
                 onClick={handleHeadClick}
                 onLongPress={onLongPress}
+                leftElements={leftElements}
                 rightElements={rightElements}
                 subtitle={subtitle}
                 shouldShowRoundImage={shouldShowRoundImage}

--- a/packages/core/src/components/list/list-item/list-item-head/ListItemHead.styles.ts
+++ b/packages/core/src/components/list/list-item/list-item-head/ListItemHead.styles.ts
@@ -29,37 +29,6 @@ export const StyledMotionListItemHeadIndicator = styled(motion.div)`
     width: 26px;
 `;
 
-type StyledListItemHeadImageWrapperProps = WithTheme<{
-    shouldShowRoundImage?: boolean;
-}>;
-
-export const StyledListItemHeadImageWrapper = styled.div<StyledListItemHeadImageWrapperProps>`
-    background-color: rgba(
-        ${({ theme }: StyledListItemHeadImageWrapperProps) => theme['text-rgb']},
-        0.1
-    );
-    border-radius: ${({ shouldShowRoundImage }) => (shouldShowRoundImage ? '50%' : undefined)};
-    box-shadow: 0 0 0 1px
-        rgba(${({ theme }: StyledListItemHeadImageWrapperProps) => theme['009-rgb']}, 0.08) inset;
-    flex: 0 0 auto;
-    height: 40px;
-    overflow: hidden;
-    transition: border-radius 0.3s ease;
-    width: 40px;
-`;
-
-type StyledListItemHeadImageProps = {
-    isHidden: boolean;
-};
-
-export const StyledListItemHeadImage = styled.img<StyledListItemHeadImageProps>`
-    height: 100%;
-    object-fit: cover;
-    opacity: ${({ isHidden }) => (isHidden ? 0 : 1)};
-    transition: opacity 0.4s ease;
-    width: 100%;
-`;
-
 type StyledListItemHeadContentProps = {
     isIconOrImageGiven: boolean;
     isOpen: boolean;

--- a/packages/core/src/components/list/list-item/list-item-head/ListItemHead.styles.ts
+++ b/packages/core/src/components/list/list-item/list-item-head/ListItemHead.styles.ts
@@ -29,21 +29,6 @@ export const StyledMotionListItemHeadIndicator = styled(motion.div)`
     width: 26px;
 `;
 
-type StyledListItemHeadIconProps = WithTheme<unknown>;
-
-export const StyledListItemHeadIcon = styled.div`
-    align-items: center;
-    background-color: rgba(${({ theme }: StyledListItemHeadIconProps) => theme['text-rgb']}, 0.1);
-    box-shadow: 0 0 0 1px
-        rgba(${({ theme }: StyledListItemHeadIconProps) => theme['009-rgb']}, 0.08) inset;
-    display: flex;
-    flex: 0 0 auto;
-    height: 40px;
-    justify-content: center;
-    margin-right: 10px;
-    width: 40px;
-`;
-
 type StyledListItemHeadImageWrapperProps = WithTheme<{
     shouldShowRoundImage?: boolean;
 }>;

--- a/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
+++ b/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
@@ -36,6 +36,7 @@ type ListItemHeadProps = {
     onLongPress?: TouchEventHandler<HTMLDivElement>;
     rightElements?: [ReactNode, ...ReactNode[]];
     subtitle?: ReactNode;
+    left?: ReactNode;
     shouldShowRoundImage?: boolean;
     title: ReactNode;
 };
@@ -53,6 +54,7 @@ const ListItemHead: FC<ListItemHeadProps> = ({
     subtitle,
     shouldShowRoundImage,
     title,
+    left,
 }) => {
     const [shouldShowHoverItem, setShouldShowHoverItem] = useState(false);
 
@@ -108,6 +110,7 @@ const ListItemHead: FC<ListItemHeadProps> = ({
                     {isExpandable && <Icon icons={['fa fa-chevron-right']} />}
                 </StyledMotionListItemHeadIndicator>
             )}
+            {left}
             {iconOrImageElement}
             <StyledListItemHeadContent
                 isIconOrImageGiven={iconOrImageElement !== undefined}

--- a/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
+++ b/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
@@ -8,15 +8,13 @@ import React, {
     useRef,
     useState,
 } from 'react';
-import GridImage from '../../../grid-image/GridImage';
 import Icon from '../../../icon/Icon';
 import ListItemIcon from './list-item-icon/ListItemIcon';
+import ListItemImage from './list-item-image/ListItemImage';
 import {
     StyledListItemHead,
     StyledListItemHeadBottomRightElement,
     StyledListItemHeadContent,
-    StyledListItemHeadImage,
-    StyledListItemHeadImageWrapper,
     StyledListItemHeadRightElement,
     StyledListItemHeadSubtitle,
     StyledListItemHeadSubtitleText,
@@ -56,14 +54,9 @@ const ListItemHead: FC<ListItemHeadProps> = ({
     shouldShowRoundImage,
     title,
 }) => {
-    const [hasLoadedImage, setHasLoadedImage] = useState(false);
     const [shouldShowHoverItem, setShouldShowHoverItem] = useState(false);
 
     const longPressTimeoutRef = useRef<number>();
-
-    const handleImageLoaded = useCallback(() => {
-        setHasLoadedImage(true);
-    }, []);
 
     const handleMouseEnter = useCallback(() => setShouldShowHoverItem(true), []);
 
@@ -89,32 +82,12 @@ const ListItemHead: FC<ListItemHeadProps> = ({
             return <ListItemIcon icons={icons} />;
         }
 
-        if (images && images[0] && images[1] && images[2]) {
-            const gridImages = [images[0], images[1], images[2]];
-
-            return (
-                <GridImage
-                    images={gridImages}
-                    shouldShowRoundImage={shouldShowRoundImage}
-                    size={40}
-                />
-            );
-        }
-
-        if (images && images[0]) {
-            return (
-                <StyledListItemHeadImageWrapper shouldShowRoundImage={shouldShowRoundImage}>
-                    <StyledListItemHeadImage
-                        isHidden={!hasLoadedImage}
-                        onLoad={handleImageLoaded}
-                        src={images[0]}
-                    />
-                </StyledListItemHeadImageWrapper>
-            );
+        if (images) {
+            return <ListItemImage images={images} shouldShowRoundImage={!!shouldShowRoundImage} />;
         }
 
         return undefined;
-    }, [handleImageLoaded, hasLoadedImage, icons, images, shouldShowRoundImage]);
+    }, [icons, images, shouldShowRoundImage]);
 
     return (
         <StyledListItemHead

--- a/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
+++ b/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
@@ -10,11 +10,11 @@ import React, {
 } from 'react';
 import GridImage from '../../../grid-image/GridImage';
 import Icon from '../../../icon/Icon';
+import ListItemIcon from './list-item-icon/ListItemIcon';
 import {
     StyledListItemHead,
     StyledListItemHeadBottomRightElement,
     StyledListItemHeadContent,
-    StyledListItemHeadIcon,
     StyledListItemHeadImage,
     StyledListItemHeadImageWrapper,
     StyledListItemHeadRightElement,
@@ -86,11 +86,7 @@ const ListItemHead: FC<ListItemHeadProps> = ({
 
     const iconOrImageElement = useMemo(() => {
         if (icons) {
-            return (
-                <StyledListItemHeadIcon>
-                    <Icon icons={icons} size={22} />
-                </StyledListItemHeadIcon>
-            );
+            return <ListItemIcon icons={icons} />;
         }
 
         if (images && images[0] && images[1] && images[2]) {

--- a/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
+++ b/packages/core/src/components/list/list-item/list-item-head/ListItemHead.tsx
@@ -36,7 +36,7 @@ type ListItemHeadProps = {
     onLongPress?: TouchEventHandler<HTMLDivElement>;
     rightElements?: [ReactNode, ...ReactNode[]];
     subtitle?: ReactNode;
-    left?: ReactNode;
+    leftElements?: ReactNode;
     shouldShowRoundImage?: boolean;
     title: ReactNode;
 };
@@ -54,7 +54,7 @@ const ListItemHead: FC<ListItemHeadProps> = ({
     subtitle,
     shouldShowRoundImage,
     title,
-    left,
+    leftElements,
 }) => {
     const [shouldShowHoverItem, setShouldShowHoverItem] = useState(false);
 
@@ -110,7 +110,7 @@ const ListItemHead: FC<ListItemHeadProps> = ({
                     {isExpandable && <Icon icons={['fa fa-chevron-right']} />}
                 </StyledMotionListItemHeadIndicator>
             )}
-            {left}
+            {leftElements}
             {iconOrImageElement}
             <StyledListItemHeadContent
                 isIconOrImageGiven={iconOrImageElement !== undefined}

--- a/packages/core/src/components/list/list-item/list-item-head/list-item-icon/ListItemIcon.styles.ts
+++ b/packages/core/src/components/list/list-item/list-item-head/list-item-icon/ListItemIcon.styles.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import type { WithTheme } from '../../../../color-scheme-provider/ColorSchemeProvider';
+
+type StyledListItemIconProps = WithTheme<unknown>;
+
+export const StyledListItemIcon = styled.div`
+    align-items: center;
+    background-color: rgba(${({ theme }: StyledListItemIconProps) => theme['text-rgb']}, 0.1);
+    box-shadow: 0 0 0 1px rgba(${({ theme }: StyledListItemIconProps) => theme['009-rgb']}, 0.08)
+        inset;
+    display: flex;
+    flex: 0 0 auto;
+    height: 40px;
+    justify-content: center;
+    margin-right: 10px;
+    width: 40px;
+`;

--- a/packages/core/src/components/list/list-item/list-item-head/list-item-icon/ListItemIcon.tsx
+++ b/packages/core/src/components/list/list-item/list-item-head/list-item-icon/ListItemIcon.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Icon from '../../../../icon/Icon';
+import { StyledListItemIcon } from './ListItemIcon.styles';
+
+type ListItemIconProps = {
+    icons: string[];
+};
+
+const ListItemIcon: React.FC<ListItemIconProps> = ({ icons }) => {
+    return (
+        <StyledListItemIcon>
+            <Icon icons={icons} size={22} />
+        </StyledListItemIcon>
+    );
+};
+
+ListItemIcon.displayName = 'ListItemIcon';
+
+export default ListItemIcon;

--- a/packages/core/src/components/list/list-item/list-item-head/list-item-image/ListItemImage.styles.ts
+++ b/packages/core/src/components/list/list-item/list-item-head/list-item-image/ListItemImage.styles.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import type { WithTheme } from '../../../../color-scheme-provider/ColorSchemeProvider';
+
+type StyledListItemHeadImageWrapperProps = WithTheme<{
+    shouldShowRoundImage?: boolean;
+}>;
+
+export const StyledListItemHeadImageWrapper = styled.div<StyledListItemHeadImageWrapperProps>`
+    background-color: rgba(
+        ${({ theme }: StyledListItemHeadImageWrapperProps) => theme['text-rgb']},
+        0.1
+    );
+    border-radius: ${({ shouldShowRoundImage }) => (shouldShowRoundImage ? '50%' : undefined)};
+    box-shadow: 0 0 0 1px
+        rgba(${({ theme }: StyledListItemHeadImageWrapperProps) => theme['009-rgb']}, 0.08) inset;
+    flex: 0 0 auto;
+    height: 40px;
+    overflow: hidden;
+    transition: border-radius 0.3s ease;
+    width: 40px;
+`;
+
+type StyledListItemHeadImageProps = {
+    isHidden: boolean;
+};
+
+export const StyledListItemHeadImage = styled.img<StyledListItemHeadImageProps>`
+    height: 100%;
+    object-fit: cover;
+    opacity: ${({ isHidden }) => (isHidden ? 0 : 1)};
+    transition: opacity 0.4s ease;
+    width: 100%;
+`;

--- a/packages/core/src/components/list/list-item/list-item-head/list-item-image/ListItemImage.tsx
+++ b/packages/core/src/components/list/list-item/list-item-head/list-item-image/ListItemImage.tsx
@@ -1,0 +1,41 @@
+import React, { useCallback, useState } from 'react';
+import GridImage from '../../../../grid-image/GridImage';
+import { StyledListItemHeadImage, StyledListItemHeadImageWrapper } from './ListItemImage.styles';
+
+type ListItemImageProps = {
+    images: string[];
+    shouldShowRoundImage: boolean;
+};
+
+const ListItemImage: React.FC<ListItemImageProps> = ({ images, shouldShowRoundImage }) => {
+    const [hasLoadedImage, setHasLoadedImage] = useState(false);
+    const handleImageLoaded = useCallback(() => {
+        setHasLoadedImage(true);
+    }, []);
+
+    if (images && images[0] && images[1] && images[2]) {
+        const gridImages = [images[0], images[1], images[2]];
+
+        return (
+            <GridImage images={gridImages} shouldShowRoundImage={shouldShowRoundImage} size={40} />
+        );
+    }
+
+    if (images && images[0]) {
+        return (
+            <StyledListItemHeadImageWrapper shouldShowRoundImage={shouldShowRoundImage}>
+                <StyledListItemHeadImage
+                    isHidden={!hasLoadedImage}
+                    onLoad={handleImageLoaded}
+                    src={images[0]}
+                />
+            </StyledListItemHeadImageWrapper>
+        );
+    }
+
+    return null;
+};
+
+ListItemImage.displayName = 'ListItemImage';
+
+export default ListItemImage;


### PR DESCRIPTION
I have split the icon/images components from the ListItemHead component. The individual components could be imported by a project to implement custom compositions of the components (should it be needed).
To allow the developers to use composition, there was a leftElements-prop added to the ListItem(Head).

Maybe we could also reduce the complexity of the component further by removing the "helper"-props images/icons/shouldShowRoundImage. They could be added later, when we know exactly which uses-cases are often needed (this could be decided by a survey on components.chayns.net).

Example (ListItem with icon):
```jsx
<ListItem
  leftElements={<ListItemIcon icons={["ts-chayns"]} />}
/>
```