### PR TITLE
📝 Add rectangular property of filter buttons to the readme

### DIFF
--- a/docs/components/filter-button.md
+++ b/docs/components/filter-button.md
@@ -53,6 +53,7 @@ The `FilterButton`-component takes the following props:
 | [disabled](#disabled)               | `boolean`                                        | `false` |          |
 | [stopPropagation](#stoppropagation) | `boolean`                                        | `false` |          |
 | [small](#small)                     | `boolean`                                        | `false` |          |
+| [rectangular](#rectangular)         | `boolean`                                        | `false` |          |
 
 ### `label`
 
@@ -189,3 +190,13 @@ small?: boolean
 ```
 
 Shrinks the filter button in size.
+
+---
+
+### `rectangular`
+
+```ts
+rectangular?: boolean
+```
+
+Makes the filter button rectangular.


### PR DESCRIPTION
I forgot to add the rectangular property to the filter-button.md, when I worked on the add-filter-button-shape feature.