### PR TITLE
Upload images to image-service-api-v3

### DIFF
--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -39,24 +39,23 @@ import { Tooltip } from 'chayns-components';
 
 The `Tooltip`-component takes the following props:
 
-| Name                                        | Type                                                                                                                       | Default                                                    | Required |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | :------: |
-| [content](#content)                         | `{ text: string, headline: string, imageUrl: string, buttonText: string, buttonOnClick: function } \| { html: ReactNode }` |                                                            |    ✓     |
-| [children](#children)                       | `ReactNode`                                                                                                                |                                                            |          |
-| [bindListeners](#bindlisteners)             | `boolean`                                                                                                                  | `false`                                                    |          |
-| [position](#position)                       | `number`                                                                                                                   |                                                            |          |
-| [minWidth](#minwidth)                       | `number`                                                                                                                   | `100`                                                      |          |
-| [maxWidth](#maxwidth)                       | `number`                                                                                                                   | `250`                                                      |          |
-| [removeIcon](#removeicon)                   | `boolean`                                                                                                                  | `typeof chayns !== 'undefined' ? chayns.env.isIOS : false` |          |
-| [parent](#parent)                           | `custom`                                                                                                                   |                                                            |          |
-| [coordinates](#coordinates)                 | `{ x: number, y: number }`                                                                                                 |                                                            |          |
-| [childrenStyle](#childrenstyle)             | `{ [key: string]: string \| number }`                                                                                      |                                                            |          |
-| [childrenClassNames](#childrenclassnames)   | `string`                                                                                                                   |                                                            |          |
-| [preventTriggerStyle](#preventtriggerstyle) | `boolean`                                                                                                                  | `false`                                                    |          |
-| [hideOnChildrenLeave](#hideonchildrenleave) | `boolean`                                                                                                                  | `false`                                                    |          |
-| [removeParentSpace](#removeparentspace)     | `boolean`                                                                                                                  | `false`                                                    |          |
-| [isIOS](#isios)                             | `boolean`                                                                                                                  | `typeof chayns !== 'undefined' ? chayns.env.isIOS : false` |          |
-| [stopPropagation](#stoppropagation)         | `boolean`                                                                                                                  | `false`                                                    |          |
+| Name                                        | Type                                                                                                                       | Default | Required |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------- | :------: |
+| [content](#content)                         | `{ text: string, headline: string, imageUrl: string, buttonText: string, buttonOnClick: function } \| { html: ReactNode }` |         |    ✓     |
+| [children](#children)                       | `ReactNode`                                                                                                                |         |          |
+| [bindListeners](#bindlisteners)             | `boolean`                                                                                                                  | `false` |          |
+| [position](#position)                       | `number`                                                                                                                   |         |          |
+| [minWidth](#minwidth)                       | `number`                                                                                                                   | `100`   |          |
+| [maxWidth](#maxwidth)                       | `number`                                                                                                                   | `250`   |          |
+| [removeIcon](#removeicon)                   | `boolean`                                                                                                                  |         |          |
+| [parent](#parent)                           | `custom`                                                                                                                   |         |          |
+| [coordinates](#coordinates)                 | `{ x: number, y: number }`                                                                                                 |         |          |
+| [childrenStyle](#childrenstyle)             | `{ [key: string]: string \| number }`                                                                                      |         |          |
+| [childrenClassNames](#childrenclassnames)   | `string`                                                                                                                   |         |          |
+| [preventTriggerStyle](#preventtriggerstyle) | `boolean`                                                                                                                  | `false` |          |
+| [hideOnChildrenLeave](#hideonchildrenleave) | `boolean`                                                                                                                  | `false` |          |
+| [removeParentSpace](#removeparentspace)     | `boolean`                                                                                                                  | `false` |          |
+| [stopPropagation](#stoppropagation)         | `boolean`                                                                                                                  | `false` |          |
 
 ### `content`
 
@@ -202,16 +201,6 @@ removeParentSpace?: boolean
 
 Removes any padding of the page from the tooltip position. This is only needed
 when the parent is padded to the page and is relatively positioned.
-
----
-
-### `isIOS`
-
-```ts
-isIOS?: boolean
-```
-
-Wether the target device is iOS (only relevant during serverside rendering).
 
 ---
 

--- a/examples/react-chayns-file_input/Example.jsx
+++ b/examples/react-chayns-file_input/Example.jsx
@@ -41,12 +41,10 @@ const FileInputExample = () => {
 
     const upload = useCallback(() => {
         images.forEach(async (image) => {
-            const result = await imageUpload(
-                image.file || image.url,
-                'componentsTestUpload',
-                chayns.env.user.personId,
-                chayns.env.site.id
-            );
+            const result = await imageUpload(image.file || image.url, {
+                personId: chayns.env.user.personId,
+                siteId: chayns.env.site.id,
+            });
             console.log('Uploaded image', result);
             setDisplayPath(`${displayPath}${result.base}/${result.key}\n`);
         });

--- a/src/utils/imageUpload.js
+++ b/src/utils/imageUpload.js
@@ -1,93 +1,83 @@
+const IMAGE_SERVICE_API_V3_URL =
+    'https://cube.tobit.cloud/image-service/v3/Images';
+const IMAGE_RESIZER_API_URL =
+    'https://cube.tobit.cloud/image-resizer-backend/api/v1.0/image';
+
 /**
  * Uploads an image to the tsimg cloud service.
  *
  * @export
  * @param {string | File} file A URL as a string or a `File` object that should be uploaded.
- * @param {object} options either object or referenceId (deprecated)
- * @param {string} [options.referenceId]
+ * @param {object} options object
  * @param {string} [options.personId] A person is that should be associated with the uploaded image.
  * @param {string} [options.siteId] A site id that should be associated with the uploaded image.
  * @param {string} [options.accessToken=chayns.env.user.tobitAccessToken] The tobitAccessToken
- * @param {string} [options.url='https://api.tsimg.cloud/image']
  * @param {string} _personId A person is that should be associated with the uploaded image. (deprecated, use options instead)
  * @param {string} _siteId A site id that should be associated with the uploaded image. (deprecated, use options instead)
- * @param {string} [_url='https://api.tsimg.cloud/image'] (deprecated, use options instead)
  * @return {Promise<object>} The response data for the image upload.
  */
-export default async function imageUpload(
-    file,
-    options,
-    _personId,
-    _siteId,
-    _url = 'https://api.tsimg.cloud/image'
-) {
+export default async function imageUpload(file, options, _personId, _siteId) {
     const headers = new Headers({ Accept: 'application/json' });
 
-    let referenceId;
     let personId;
     let siteId;
-    let url;
     let accessToken;
     if (options && typeof options === 'object') {
-        ({ referenceId, personId, siteId, url = 'https://api.tsimg.cloud/image', accessToken } = options);
+        ({ personId, siteId, accessToken } = options);
     } else {
-        referenceId = options;
         personId = _personId;
         siteId = _siteId;
-        url = _url;
     }
 
-    if (!accessToken && typeof chayns !== 'undefined' && chayns?.env?.user?.isAuthenticated) {
+    if (
+        !accessToken &&
+        typeof chayns !== 'undefined' &&
+        chayns?.env?.user?.isAuthenticated
+    ) {
         accessToken = chayns.env.user.tobitAccessToken;
     }
 
-    if (referenceId) headers.set('X-Reference-Id', referenceId);
-    if (personId) headers.set('X-Person-Id', personId);
-    if (siteId) headers.set('X-Site-Id', siteId);
+    if (!personId) {
+        personId = chayns.env.user.personId;
+    }
+
+    const owner = siteId || personId;
+
     if (accessToken) headers.set('Authorization', `bearer ${accessToken}`);
 
-    /** @type {string | ArrayBuffer} */
-    let body;
-
+    // Build formData object.
+    const body = new FormData();
     if (typeof file === 'string') {
-        headers.set('Content-Type', 'application/json');
-        body = JSON.stringify({ url: file });
+        body.append('SourceUrl', file);
     } else {
-        headers.set('Content-Type', 'image/*');
-        body = await getFileArrayBuffer(file);
-        if (url === 'https://api.tsimg.cloud/image' && body.byteLength > 4 * 1024 * 1024) {
-            url = 'https://cube.tobit.cloud/image-resizer-backend/api/v1.0/image'
-        }
+        body.append('File', file);
     }
+
+    const url =
+        file.size > 10 * 1024 * 1024
+            ? `${IMAGE_RESIZER_API_URL}/${owner}`
+            : `${IMAGE_SERVICE_API_V3_URL}/${owner}`;
 
     const response = await fetch(url, { method: 'POST', body, headers });
 
     if (response.ok) {
-        return response.json();
+        const { image, baseDomain } = await response.json();
+        // Maps image-service-api-v3 result to v2 result.
+        return {
+            key: image.path,
+            // Removes trailing slash from baseDomain, since image-service-api-v2 doesn't have a trailing slash on base.
+            base: baseDomain.endsWith('/')
+                ? baseDomain.slice(0, -1)
+                : baseDomain,
+            meta: {
+                preview: image.preview,
+                width: image.width,
+                height: image.height,
+            },
+        };
     }
 
     throw new Error(
         `Uploading the image failed with status code ${response.status}.`
     );
-}
-
-/**
- * Returns the array buffer for an input file.
- *
- * @param {File} file The input `File` object.
- * @return {Promise<string | ArrayBuffer>}
- */
-function getFileArrayBuffer(file) {
-    return new Promise((resolve, reject) => {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-            if (e.target?.result) {
-                resolve(e.target.result);
-            } else {
-                reject(Error('Could not get array buffer.'));
-            }
-        };
-        reader.onerror = reject;
-        reader.readAsArrayBuffer(file);
-    });
 }


### PR DESCRIPTION
This feature updates the imageUpload utility function to upload images to image-service-api-v3 instead of v2. The url and referenceId options were removed from the function.