### PR TITLE
249 slider button initial state animation

### DIFF
--- a/docs/components/slider-button.md
+++ b/docs/components/slider-button.md
@@ -37,16 +37,17 @@ import { SliderButton } from 'chayns-components';
 
 The `SliderButton`-component takes the following props:
 
-| Name                              | Type                                                         | Default                                                                           | Required |
-| --------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- | :------: |
-| [className](#classname)           | `string`                                                     |                                                                                   |          |
-| [style](#style)                   | `{ [key: string]: string \| number }`                        |                                                                                   |          |
-| [items](#items)                   | `Array<{ id: string \| number, text: string \| ReactNode }>` | `[ { id: 0, text: 'Auf', }, { id: 1, text: 'Stopp', }, { id: 2, text: 'Zu', }, ]` |          |
-| [onChange](#onchange)             | `function`                                                   |                                                                                   |          |
-| [onDragStop](#ondragstop)         | `function`                                                   |                                                                                   |          |
-| [onDragStart](#ondragstart)       | `function`                                                   |                                                                                   |          |
-| [selectedItemId](#selecteditemid) | `number`                                                     | `0`                                                                               |          |
-| [disabled](#disabled)             | `boolean`                                                    | `false`                                                                           |          |
+| Name                                  | Type                                                         | Default                                                                           | Required |
+| ------------------------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------- | :------: |
+| [className](#classname)               | `string`                                                     |                                                                                   |          |
+| [style](#style)                       | `{ [key: string]: string \| number }`                        |                                                                                   |          |
+| [items](#items)                       | `Array<{ id: string \| number, text: string \| ReactNode }>` | `[ { id: 0, text: 'Auf', }, { id: 1, text: 'Stopp', }, { id: 2, text: 'Zu', }, ]` |          |
+| [onChange](#onchange)                 | `function`                                                   |                                                                                   |          |
+| [onDragStop](#ondragstop)             | `function`                                                   |                                                                                   |          |
+| [onDragStart](#ondragstart)           | `function`                                                   |                                                                                   |          |
+| [selectedItemId](#selecteditemid)     | `number`                                                     | `0`                                                                               |          |
+| [disabled](#disabled)                 | `boolean`                                                    | `false`                                                                           |          |
+| [initialAnimation](#initialanimation) | `boolean`                                                    | `true`                                                                            |          |
 
 ### `className`
 
@@ -126,3 +127,13 @@ disabled?: boolean
 
 Wether the `SliderButton` should ignore user interaction and be rendered in a
 disabled style.
+
+---
+
+### `initialAnimation`
+
+```ts
+initialAnimation?: boolean
+```
+
+Whether there should be an animation when the component is mounted.

--- a/docs/components/slider-button.md
+++ b/docs/components/slider-button.md
@@ -136,4 +136,6 @@ disabled style.
 initialAnimation?: boolean
 ```
 
-Whether there should be an animation when the component is mounted.
+Whether there should be an animation when the component is mounted. If set to
+`false`, the marker will be positioned at the selected item without any
+animation on mount.

--- a/src/react-chayns-sliderbutton/component/SliderButton.jsx
+++ b/src/react-chayns-sliderbutton/component/SliderButton.jsx
@@ -26,10 +26,13 @@ const SliderButton = (props) => {
     // We assume the buttons each have a width of 64px because it is specified
     // in the scss ($itemWidth). 0.25 is added to prevent a bug where text of
     // the marker does not match the text of the hovered item.
+    const itemWidth = 64; // $itemWidth in scss
     const [markerPosX, setMarkerPosX] = useState(
         initialAnimation
             ? 0
-            : items.findIndex((item) => item.id === selectedItemId) * 64 + 0.25
+            : items.findIndex((item) => item.id === selectedItemId) *
+                  itemWidth +
+                  0.25
     );
     const [dragStartPosX, setDragStartPosX] = useState(null);
     const [dragStartMarkerPosX, setDragStartMarkerPosX] = useState(null);

--- a/src/react-chayns-sliderbutton/component/SliderButton.jsx
+++ b/src/react-chayns-sliderbutton/component/SliderButton.jsx
@@ -23,7 +23,14 @@ const SliderButton = (props) => {
         initialAnimation,
     } = props;
 
-    const [markerPosX, setMarkerPosX] = useState(0);
+    // We assume the buttons each have a width of 64px because it is specified
+    // in the scss ($itemWidth). 0.25 is added to prevent a bug where text of
+    // the marker does not match the text of the hovered item.
+    const [markerPosX, setMarkerPosX] = useState(
+        initialAnimation
+            ? 0
+            : items.findIndex((item) => item.id === selectedItemId) * 64 + 0.25
+    );
     const [dragStartPosX, setDragStartPosX] = useState(null);
     const [dragStartMarkerPosX, setDragStartMarkerPosX] = useState(null);
     const [lastSelectedIndex, setLastSelectedIndex] = useState(selectedItemId);

--- a/src/react-chayns-sliderbutton/component/SliderButton.jsx
+++ b/src/react-chayns-sliderbutton/component/SliderButton.jsx
@@ -20,6 +20,7 @@ const SliderButton = (props) => {
         onDragStart,
         selectedItemId,
         disabled,
+        initialAnimation,
     } = props;
 
     const [markerPosX, setMarkerPosX] = useState(0);
@@ -272,6 +273,11 @@ SliderButton.propTypes = {
      * in a disabled style.
      */
     disabled: PropTypes.bool,
+
+    /**
+     * Whether there should be an animation when the component is mounted.
+     */
+    initialAnimation: PropTypes.bool,
 };
 
 SliderButton.defaultProps = {
@@ -296,6 +302,7 @@ SliderButton.defaultProps = {
     onDragStart: null,
     selectedItemId: 0,
     disabled: false,
+    initialAnimation: true,
 };
 
 SliderButton.displayName = 'SliderButton';

--- a/src/react-chayns-sliderbutton/component/SliderButton.jsx
+++ b/src/react-chayns-sliderbutton/component/SliderButton.jsx
@@ -29,13 +29,13 @@ const SliderButton = (props) => {
     const [lastSelectedIndex, setLastSelectedIndex] = useState(selectedItemId);
 
     const sliderButtonRef = useRef();
-    const sliderButton = sliderButtonRef && sliderButtonRef.current;
+    const sliderButton = sliderButtonRef?.current;
 
     const firstItemRef = useRef();
-    let firstItem = firstItemRef && firstItemRef.current;
+    let firstItem = firstItemRef?.current;
 
     const markerRef = useRef();
-    let marker = markerRef && markerRef.current;
+    let marker = markerRef?.current;
 
     const handleChange = (newIndex) => {
         if (newIndex !== lastSelectedIndex) {

--- a/src/react-chayns-sliderbutton/component/SliderButton.jsx
+++ b/src/react-chayns-sliderbutton/component/SliderButton.jsx
@@ -285,7 +285,7 @@ SliderButton.propTypes = {
     disabled: PropTypes.bool,
 
     /**
-     * Whether there should be an animation when the component is mounted.
+     * Whether there should be an animation when the component is mounted. If set to `false`, the marker will be positioned at the selected item without any animation on mount.
      */
     initialAnimation: PropTypes.bool,
 };


### PR DESCRIPTION
## Describe your changes
Hi. The `SliderButton` component had an unexpected behavior. The “problem” or the reason for the behavior was the initial state of `markerPosX`. It is 0 initially and directly after that the correct value is set, but this is visually expressed by a CSS transition, which causes the initial animation.

I added a new prop `initialAnimation` that defaults to `true` so we do not have breaking changes. If set to `false`, the proper item is selected without the bezier animation.

## Issue ticket number and link
#249 