### PR TITLE
✨ Add React Compiler support with ESLint integration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 *.stories.tsx
 generate-docs.ts
+.eslintrc.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,8 +24,6 @@ module.exports = {
                 mjs: 'never',
             },
         ],
-        'react-hooks/rules-of-hooks': 'warn',
-        'react-hooks/exhaustive-deps': 'warn',
     },
     extends: ['@chayns-toolkit', 'plugin:storybook/recommended', 'plugin:react-hooks/recommended'],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    plugins: ['react-hooks'],
     rules: {
         '@typescript-eslint/no-misused-promises': [
             'error',
@@ -23,6 +24,8 @@ module.exports = {
                 mjs: 'never',
             },
         ],
+        'react-hooks/rules-of-hooks': 'warn',
+        'react-hooks/exhaustive-deps': 'warn',
     },
-    extends: ['@chayns-toolkit', 'plugin:storybook/recommended'],
+    extends: ['@chayns-toolkit', 'plugin:storybook/recommended', 'plugin:react-hooks/recommended'],
 };

--- a/babel.config.mjs
+++ b/babel.config.mjs
@@ -1,4 +1,5 @@
 export default {
+    plugins: [['babel-plugin-react-compiler', { target: '18' }]],
     env: {
         esm: {
             sourceType: 'unambiguous',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
             "workspaces": [
                 "packages/*"
             ],
+            "dependencies": {
+                "react-compiler-runtime": "^1.0.0"
+            },
             "devDependencies": {
                 "@babel/cli": "^7.28.3",
                 "@babel/core": "^7.28.5",
@@ -26,6 +29,7 @@
                 "@storybook/react-webpack5": "^7.6.20",
                 "@types/uuid": "^10.0.0",
                 "babel-loader": "^9.2.1",
+                "babel-plugin-react-compiler": "^1.0.0",
                 "concurrently": "^9.2.1",
                 "eslint": "^8.57.1",
                 "eslint-plugin-storybook": "^0.12.0",
@@ -11989,6 +11993,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/babel-plugin-react-compiler": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+            "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.26.0"
             }
         },
         "node_modules/bail": {
@@ -25103,6 +25117,15 @@
             "peerDependencies": {
                 "react": ">=16.8.0",
                 "react-dom": ">=16.8.0"
+            }
+        },
+        "node_modules/react-compiler-runtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/react-compiler-runtime/-/react-compiler-runtime-1.0.0.tgz",
+            "integrity": "sha512-rRfjYv66HlG8896yPUDONgKzG5BxZD1nV9U6rkm+7VCuvQc903C4MjcoZR4zPw53IKSOX9wMQVpA1IAbRtzQ7w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^0.0.0-experimental"
             }
         },
         "node_modules/react-docgen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
                 "babel-plugin-react-compiler": "^1.0.0",
                 "concurrently": "^9.2.1",
                 "eslint": "^8.57.1",
+                "eslint-plugin-react-hooks": "^7.0.1",
                 "eslint-plugin-storybook": "^0.12.0",
                 "form-data": "^4.0.5",
                 "husky": "^8.0.3",
@@ -2055,6 +2056,41 @@
             },
             "peerDependencies": {
                 "eslint": ">=7"
+            }
+        },
+        "node_modules/@chayns-toolkit/eslint-config/node_modules/eslint-config-airbnb": {
+            "version": "19.0.4",
+            "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+            "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "eslint-config-airbnb-base": "^15.0.0",
+                "object.assign": "^4.1.2",
+                "object.entries": "^1.1.5"
+            },
+            "engines": {
+                "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "peerDependencies": {
+                "eslint": "^7.32.0 || ^8.2.0",
+                "eslint-plugin-import": "^2.25.3",
+                "eslint-plugin-jsx-a11y": "^6.5.1",
+                "eslint-plugin-react": "^7.28.0",
+                "eslint-plugin-react-hooks": "^4.3.0"
+            }
+        },
+        "node_modules/@chayns-toolkit/eslint-config/node_modules/eslint-plugin-react-hooks": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
+            "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
             }
         },
         "node_modules/@chayns/colors": {
@@ -15121,28 +15157,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint-config-airbnb": {
-            "version": "19.0.4",
-            "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-            "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "eslint-config-airbnb-base": "^15.0.0",
-                "object.assign": "^4.1.2",
-                "object.entries": "^1.1.5"
-            },
-            "engines": {
-                "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "peerDependencies": {
-                "eslint": "^7.32.0 || ^8.2.0",
-                "eslint-plugin-import": "^2.25.3",
-                "eslint-plugin-jsx-a11y": "^6.5.1",
-                "eslint-plugin-react": "^7.28.0",
-                "eslint-plugin-react-hooks": "^4.3.0"
-            }
-        },
         "node_modules/eslint-config-airbnb-base": {
             "version": "15.0.0",
             "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
@@ -15409,16 +15423,23 @@
             }
         },
         "node_modules/eslint-plugin-react-hooks": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-            "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+            "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "@babel/core": "^7.24.4",
+                "@babel/parser": "^7.24.4",
+                "hermes-parser": "^0.25.1",
+                "zod": "^3.25.0 || ^4.0.0",
+                "zod-validation-error": "^3.5.0 || ^4.0.0"
+            },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "peerDependencies": {
-                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+                "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
             }
         },
         "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -17643,6 +17664,23 @@
             "license": "MIT",
             "bin": {
                 "he": "bin/he"
+            }
+        },
+        "node_modules/hermes-estree": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+            "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/hermes-parser": {
+            "version": "0.25.1",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+            "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "hermes-estree": "0.25.1"
             }
         },
         "node_modules/highlight.js": {
@@ -30303,6 +30341,29 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+            "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zod-validation-error": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+            "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "zod": "^3.25.0 || ^4.0.0"
             }
         },
         "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "concurrently": "^9.2.1",
         "eslint": "^8.57.1",
+        "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-storybook": "^0.12.0",
         "form-data": "^4.0.5",
         "husky": "^8.0.3",

--- a/package.json
+++ b/package.json
@@ -62,9 +62,11 @@
         "@storybook/react-webpack5": "^7.6.20",
         "@types/uuid": "^10.0.0",
         "babel-loader": "^9.2.1",
+        "babel-plugin-react-compiler": "^1.0.0",
         "concurrently": "^9.2.1",
         "eslint": "^8.57.1",
         "eslint-plugin-storybook": "^0.12.0",
+        "form-data": "^4.0.5",
         "husky": "^8.0.3",
         "lerna": "^9.0.3",
         "motion": "^12.23.24",
@@ -75,7 +77,9 @@
         "storybook": "^7.6.20",
         "ts-morph": "^27.0.2",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3",
-        "form-data": "^4.0.5"
+        "typescript": "^5.9.3"
+    },
+    "dependencies": {
+        "react-compiler-runtime": "^1.0.0"
     }
 }


### PR DESCRIPTION
## Changes
- Add `babel-plugin-react-compiler` for automatic memoization
- Add `react-compiler-runtime` for React 18 compatibility
- Add `eslint-plugin-react-hooks` with recommended rules (set to warn)