### PR TITLE
Sharing components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,5 @@
 *.stories.tsx
 generate-docs.ts
+packages/**/lib
+packages/**/node_modules
+*.docs.tsx

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,12 @@
 module.exports = {
     rules: {
-        '@typescript-eslint/no-misused-promises': [
-            'error',
-            {
-                checksVoidReturn: false,
-            },
-        ],
+        // not properly setup and this is already handled in chayns-toolkit base config
+        // '@typescript-eslint/no-misused-promises': [
+        //     'error',
+        //     {
+        //         checksVoidReturn: false,
+        //     },
+        // ],
         'no-void': 'off',
         // We organize imports on commit so this is not needed.
         'import/order': 'off',
@@ -25,4 +26,8 @@ module.exports = {
         ],
     },
     extends: ['@chayns-toolkit', 'plugin:storybook/recommended'],
+    // use another tsconfig for linting to avoid including test files and other non-source files
+    parserOptions: {
+        project: './tsconfig.lint.json',
+    },
 };

--- a/packages/core/src/components/accordion/accordion-content/AccordionContent.tsx
+++ b/packages/core/src/components/accordion/accordion-content/AccordionContent.tsx
@@ -1,7 +1,6 @@
 import { getDevice } from 'chayns-api';
 import React, { FC, ReactNode, UIEvent } from 'react';
 import { BrowserName } from '../../../types/chayns';
-import { AccordionContext } from '../Accordion';
 import { StyledAccordionContent } from './AccordionContent.styles';
 
 export type AccordionContentProps = {

--- a/packages/core/src/components/amount-control/AmountControl.styles.ts
+++ b/packages/core/src/components/amount-control/AmountControl.styles.ts
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import styled, { css } from 'styled-components';
-import type { Theme, WithTheme } from '../color-scheme-provider/ColorSchemeProvider';
+import type { WithTheme } from '../color-scheme-provider/ColorSchemeProvider';
 import type { DisplayState } from './AmountControl';
 
 type StyledAmountControlProps = WithTheme<{

--- a/packages/core/src/components/icon/Icon.styles.ts
+++ b/packages/core/src/components/icon/Icon.styles.ts
@@ -1,6 +1,5 @@
 import styled, { css } from 'styled-components';
 import type { WithTheme } from '../color-scheme-provider/ColorSchemeProvider';
-import { motion } from 'motion/react';
 
 type StyledIconWrapperProps = {
     $isDisabled?: boolean;

--- a/packages/core/src/components/search-input/SearchInput.tsx
+++ b/packages/core/src/components/search-input/SearchInput.tsx
@@ -2,7 +2,6 @@ import { AnimatePresence } from 'motion/react';
 import React, {
     ChangeEventHandler,
     CSSProperties,
-    FC,
     forwardRef,
     useCallback,
     useEffect,

--- a/packages/core/src/components/sharing-bar/SharingBar.tsx
+++ b/packages/core/src/components/sharing-bar/SharingBar.tsx
@@ -1,9 +1,4 @@
-import { getSite } from 'chayns-api';
 import React, { FC, MouseEventHandler, useCallback, useRef } from 'react';
-import { SHAREPROVIDER } from '../../constants/sharingBar';
-import { useIsTouch } from '../../utils/environment';
-import { copyToClipboard, shareWithApp, shareWithUrl } from '../../utils/sharingBar';
-import ContextMenu from '../context-menu/ContextMenu';
 import Icon from '../icon/Icon';
 import {
     StyledSharingBar,
@@ -11,6 +6,7 @@ import {
     StyledSharingBarText,
 } from './SharingBar.styles';
 import type { ContextMenuAlignment } from '../context-menu/ContextMenu.types';
+import SharingContextMenu from '../sharing-context-menu/SharingContextMenu';
 
 export type SharingBarProps = {
     /**
@@ -34,102 +30,6 @@ export type SharingBarProps = {
 const SharingBar: FC<SharingBarProps> = ({ label, link, popupAlignment, container }) => {
     const contextMenuRef = useRef<{ hide: VoidFunction; show: VoidFunction }>(null);
 
-    const handleImageDownload = () => {
-        shareWithUrl(
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            SHAREPROVIDER[5].url
-                .replace('{url}', encodeURIComponent(link))
-                .replace('{linkText}', 'Teilen')
-                .replace('{color}', getSite().color.replace('#', '')),
-        );
-    };
-
-    const isTouch = useIsTouch();
-
-    const handleShare = (key: string) => {
-        contextMenuRef.current?.hide();
-
-        switch (key) {
-            case 'whatsapp':
-                shareWithUrl(
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
-                    SHAREPROVIDER[0].url.replace('{url}', encodeURIComponent(`${link}`.trim())),
-                );
-                break;
-            case 'facebook':
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                shareWithUrl(SHAREPROVIDER[3].url.replace('{url}', encodeURIComponent(link)));
-                break;
-            case 'twitter':
-                shareWithUrl(
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
-                    SHAREPROVIDER[4].url
-                        .replace('{url}', encodeURIComponent(link))
-                        .replace('{linkText}', ''),
-                );
-                break;
-            case 'mail':
-                if (isTouch) {
-                    shareWithApp(`${link}`.trim());
-                } else {
-                    shareWithUrl(
-                        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                        // @ts-ignore
-                        SHAREPROVIDER[2].url.replace('{url}', encodeURIComponent(`${link}`.trim())),
-                    );
-                }
-                break;
-            case 'copy':
-                copyToClipboard(link);
-                break;
-            default:
-                break;
-        }
-    };
-
-    const contextMenuItems = [
-        {
-            icons: ['fa fa-copy'],
-            key: 'copy',
-            onClick: () => handleShare('copy'),
-            text: 'Zwischenablage',
-        },
-        {
-            icons: ['fa-solid fa-brands fa-whatsapp'],
-            key: 'whatsapp',
-            onClick: () => handleShare('whatsapp'),
-            text: 'Whatsapp',
-        },
-        {
-            icons: ['fa-solid fa-brands fa-facebook-f'],
-            key: 'facebook',
-            onClick: () => handleShare('facebook'),
-            text: 'Facebook',
-        },
-        {
-            icons: ['fa-solid fa-brands fa-x-twitter'],
-            key: 'twitter',
-            onClick: () => handleShare('twitter'),
-            text: 'X',
-        },
-        {
-            icons: ['fa fa-envelope'],
-            key: 'mail',
-            onClick: () => handleShare('mail'),
-            text: 'Mail',
-        },
-        {
-            icons: ['fa fa-qrcode'],
-            key: 'callingCode',
-            onClick: handleImageDownload,
-            text: 'Calling Code herunterladen',
-        },
-    ];
-
     const handleSharingBarClick = useCallback<MouseEventHandler<HTMLDivElement>>((event) => {
         event.preventDefault();
         event.stopPropagation();
@@ -142,14 +42,14 @@ const SharingBar: FC<SharingBarProps> = ({ label, link, popupAlignment, containe
             <StyledSharingBarIconWrapper>
                 <Icon icons={['fa-solid fa-share-nodes']} />
             </StyledSharingBarIconWrapper>
-            <ContextMenu
-                items={contextMenuItems}
+            <SharingContextMenu
+                link={link}
                 ref={contextMenuRef}
                 alignment={popupAlignment}
                 container={container}
             >
                 {null}
-            </ContextMenu>
+            </SharingContextMenu>
             <StyledSharingBarText>{label}</StyledSharingBarText>
         </StyledSharingBar>
     );

--- a/packages/core/src/components/sharing-button/SharingButton.styles.ts
+++ b/packages/core/src/components/sharing-button/SharingButton.styles.ts
@@ -1,0 +1,5 @@
+import { styled } from 'styled-components';
+
+export const StyledSharingButtonContainer = styled.div`
+    width: fit-content;
+`;

--- a/packages/core/src/components/sharing-button/SharingButton.tsx
+++ b/packages/core/src/components/sharing-button/SharingButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, PropsWithChildren } from 'react';
 import { ContextMenuRef } from '../context-menu/ContextMenu.types';
 import SharingContextMenu, {
     SharingContextMenuProps,
@@ -6,9 +6,16 @@ import SharingContextMenu, {
 import { StyledSharingButtonContainer } from './SharingButton.styles';
 import Button from '../button/Button';
 
-export type SharingButtonProps = Pick<SharingContextMenuProps, 'link' | 'alignment' | 'container'>;
+export type SharingButtonProps = PropsWithChildren<
+    Pick<SharingContextMenuProps, 'link' | 'alignment' | 'container'>
+>;
 
-const SharingButton: FunctionComponent<SharingButtonProps> = ({ link, alignment, container }) => {
+const SharingButton: FunctionComponent<SharingButtonProps> = ({
+    link,
+    alignment,
+    container,
+    children,
+}) => {
     const contextMenuRef = React.useRef<ContextMenuRef>(null);
     const [isButtonDisabled, setIsButtonDisabled] = React.useState(false);
 
@@ -35,7 +42,7 @@ const SharingButton: FunctionComponent<SharingButtonProps> = ({ link, alignment,
                 onHide={handleOnHide}
             >
                 <Button onClick={handleButtonClick} isDisabled={isButtonDisabled}>
-                    Teilen
+                    {children}
                 </Button>
             </SharingContextMenu>
         </StyledSharingButtonContainer>

--- a/packages/core/src/components/sharing-button/SharingButton.tsx
+++ b/packages/core/src/components/sharing-button/SharingButton.tsx
@@ -1,0 +1,45 @@
+import React, { FunctionComponent } from 'react';
+import { ContextMenuRef } from '../context-menu/ContextMenu.types';
+import SharingContextMenu, {
+    SharingContextMenuProps,
+} from '../sharing-context-menu/SharingContextMenu';
+import { StyledSharingButtonContainer } from './SharingButton.styles';
+import Button from '../button/Button';
+
+export type SharingButtonProps = Pick<SharingContextMenuProps, 'link' | 'alignment' | 'container'>;
+
+const SharingButton: FunctionComponent<SharingButtonProps> = ({ link, alignment, container }) => {
+    const contextMenuRef = React.useRef<ContextMenuRef>(null);
+    const [isButtonDisabled, setIsButtonDisabled] = React.useState(false);
+
+    const handleButtonClick = () => {
+        contextMenuRef.current?.show();
+    };
+
+    const handleOnShow = () => {
+        setIsButtonDisabled(true);
+    };
+
+    const handleOnHide = () => {
+        setIsButtonDisabled(false);
+    };
+
+    return (
+        <StyledSharingButtonContainer>
+            <SharingContextMenu
+                link={link}
+                alignment={alignment}
+                container={container}
+                ref={contextMenuRef}
+                onShow={handleOnShow}
+                onHide={handleOnHide}
+            >
+                <Button onClick={handleButtonClick} isDisabled={isButtonDisabled}>
+                    Teilen
+                </Button>
+            </SharingContextMenu>
+        </StyledSharingButtonContainer>
+    );
+};
+
+export default SharingButton;

--- a/packages/core/src/components/sharing-context-menu/SharingContextMenu.tsx
+++ b/packages/core/src/components/sharing-context-menu/SharingContextMenu.tsx
@@ -1,0 +1,133 @@
+import { getSite } from 'chayns-api';
+import { forwardRef, useCallback } from 'react';
+import { SHAREPROVIDER } from '../../constants/sharingBar';
+import { useIsTouch } from '../../utils/environment';
+import { copyToClipboard, shareWithApp, shareWithUrl } from '../../utils/sharingBar';
+import ContextMenu from '../context-menu/ContextMenu';
+import { ContextMenuProps, ContextMenuRef } from '../context-menu/ContextMenu.types';
+
+export type SharingContextMenuProps = {
+    /**
+     * The link that should be shared.
+     */
+    link: string;
+} & Omit<ContextMenuProps, 'items'>;
+
+const SharingContextMenu = forwardRef<ContextMenuRef, SharingContextMenuProps>(
+    ({ link, children, ...contextMenuProps }, ref) => {
+        const isTouch = useIsTouch();
+
+        const handleImageDownload = useCallback(() => {
+            shareWithUrl(
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                SHAREPROVIDER[5].url
+                    .replace('{url}', encodeURIComponent(link))
+                    .replace('{linkText}', 'Teilen')
+                    .replace('{color}', getSite().color.replace('#', '')),
+            );
+        }, [link]);
+
+        const handleShare = useCallback(
+            (key: string) => {
+                switch (key) {
+                    case 'whatsapp':
+                        shareWithUrl(
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore
+                            SHAREPROVIDER[0].url.replace(
+                                '{url}',
+                                encodeURIComponent(`${link}`.trim()),
+                            ),
+                        );
+                        break;
+                    case 'facebook':
+                        shareWithUrl(
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore
+                            SHAREPROVIDER[3].url.replace('{url}', encodeURIComponent(link)),
+                        );
+                        break;
+                    case 'twitter':
+                        shareWithUrl(
+                            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                            // @ts-ignore
+                            SHAREPROVIDER[4].url
+                                .replace('{url}', encodeURIComponent(link))
+                                .replace('{linkText}', ''),
+                        );
+                        break;
+                    case 'mail':
+                        if (isTouch) {
+                            shareWithApp(`${link}`.trim());
+                        } else {
+                            shareWithUrl(
+                                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                                // @ts-ignore
+                                SHAREPROVIDER[2].url.replace(
+                                    '{url}',
+                                    encodeURIComponent(`${link}`.trim()),
+                                ),
+                            );
+                        }
+                        break;
+                    case 'copy':
+                        copyToClipboard(link);
+                        break;
+                    default:
+                        break;
+                }
+            },
+            [link, isTouch],
+        );
+
+        const contextMenuItems = [
+            {
+                icons: ['fa fa-copy'],
+                key: 'copy',
+                onClick: () => handleShare('copy'),
+                text: 'Zwischenablage',
+            },
+            {
+                icons: ['fa-solid fa-brands fa-whatsapp'],
+                key: 'whatsapp',
+                onClick: () => handleShare('whatsapp'),
+                text: 'Whatsapp',
+            },
+            {
+                icons: ['fa-solid fa-brands fa-facebook-f'],
+                key: 'facebook',
+                onClick: () => handleShare('facebook'),
+                text: 'Facebook',
+            },
+            {
+                icons: ['fa-solid fa-brands fa-x-twitter'],
+                key: 'twitter',
+                onClick: () => handleShare('twitter'),
+                text: 'X',
+            },
+            {
+                icons: ['fa fa-envelope'],
+                key: 'mail',
+                onClick: () => handleShare('mail'),
+                text: 'Mail',
+            },
+            {
+                icons: ['fa fa-qrcode'],
+                key: 'callingCode',
+                onClick: handleImageDownload,
+                text: 'Calling Code herunterladen',
+            },
+        ];
+
+        return (
+            <ContextMenu items={contextMenuItems} ref={ref} {...contextMenuProps}>
+                {children}
+            </ContextMenu>
+        );
+    },
+);
+
+SharingContextMenu.displayName = 'SharingContextMenu';
+
+export default SharingContextMenu;

--- a/packages/core/src/components/sharing-context-menu/SharingContextMenu.tsx
+++ b/packages/core/src/components/sharing-context-menu/SharingContextMenu.tsx
@@ -1,5 +1,5 @@
 import { getSite } from 'chayns-api';
-import { forwardRef, useCallback } from 'react';
+import React, { forwardRef, useCallback } from 'react';
 import { SHAREPROVIDER } from '../../constants/sharingBar';
 import { useIsTouch } from '../../utils/environment';
 import { copyToClipboard, shareWithApp, shareWithUrl } from '../../utils/sharingBar';
@@ -121,6 +121,7 @@ const SharingContextMenu = forwardRef<ContextMenuRef, SharingContextMenuProps>(
         ];
 
         return (
+            // eslint-disable-next-line react/jsx-props-no-spreading
             <ContextMenu items={contextMenuItems} ref={ref} {...contextMenuProps}>
                 {children}
             </ContextMenu>

--- a/packages/core/src/components/slider/Slider.styles.ts
+++ b/packages/core/src/components/slider/Slider.styles.ts
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 import styled from 'styled-components';
-import type { Theme, WithTheme } from '../color-scheme-provider/ColorSchemeProvider';
+import type { WithTheme } from '../color-scheme-provider/ColorSchemeProvider';
 
 type StyledSliderProps = WithTheme<{ $isDisabled?: boolean }>;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,7 +103,9 @@ export { default as SelectButton } from './components/select-button/SelectButton
 export { default as SetupWizardItem } from './components/setup-wizard/setup-wizard-item/SetupWizardItem';
 export { default as SetupWizard } from './components/setup-wizard/SetupWizard';
 export type { SetupWizardRef } from './components/setup-wizard/SetupWizard';
+export { default as SharingContextMenu } from './components/sharing-context-menu/SharingContextMenu';
 export { default as SharingBar } from './components/sharing-bar/SharingBar';
+export { default as SharingButton } from './components/sharing-button/SharingButton';
 export { default as Signature } from './components/signature/Signature';
 export type { SignatureRef } from './components/signature/Signature';
 export { default as SliderButton } from './components/slider-button/SliderButton';

--- a/packages/core/stories/SharingBar.stories.tsx
+++ b/packages/core/stories/SharingBar.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
-import { ContextMenuAlignment } from '../src/types/contextMenu';
 import SharingBar from '../src/components/sharing-bar/SharingBar';
 import React from 'react';
+import { ContextMenuAlignment } from '../src';
 
 export default {
     title: 'Core/SharingBar',

--- a/packages/core/stories/SharingButton.stories.tsx
+++ b/packages/core/stories/SharingButton.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Meta, StoryFn } from '@storybook/react';
+import { ContextMenuAlignment } from '../src/components/context-menu/ContextMenu.types';
+import SharingButton from '../src/components/sharing-button/SharingButton';
+
+export default {
+    title: 'Core/SharingButton',
+    component: SharingButton,
+    args: {
+        link: 'https://components.chayns.net/',
+        alignment: ContextMenuAlignment.BottomRight,
+    },
+} as Meta<typeof SharingButton>;
+
+const Template: StoryFn<typeof SharingButton> = (args) => <SharingButton {...args} />;
+
+export const General = Template.bind({});
+
+export const TopAlignment = Template.bind({});
+TopAlignment.args = {
+    alignment: ContextMenuAlignment.TopCenter,
+};
+
+export const BottomRightAlignment = Template.bind({});
+BottomRightAlignment.args = {
+    alignment: ContextMenuAlignment.BottomRight,
+};
+
+export const CustomLink = Template.bind({});
+CustomLink.args = {
+    link: 'https://github.com/TobitSoftware/chayns-components',
+    alignment: ContextMenuAlignment.BottomLeft,
+};

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,4 @@
+{
+    "extends": "./tsconfig.json",
+    "include": ["packages/**/src/**/*.ts", "packages/**/src/**/*.tsx"]
+}


### PR DESCRIPTION
This adds a SharingButton and generalizes the SharingContextMenu. The SharingContextMenu is now used in the SharingBar and SharingButton. It is also exported from the package to reuse it with other components.
Eslint configuration is fixed.